### PR TITLE
Fixed the starting and end points of the strings in full_train_test_and_plot.bash

### DIFF
--- a/src/full_train_test_and_plot.bash
+++ b/src/full_train_test_and_plot.bash
@@ -14,8 +14,8 @@
 SKIP_DTED_TRAINING=0
 
 # NOTE: please make sure to update the two paths below as necessary.
-MPIIGAZE_FILE="../preprocess/outputs/MPIIGaze.h5
-GAZECAPTURE_FILE="../preprocess/outputs/GazeCapture.h5
+MPIIGAZE_FILE="../preprocess/outputs/MPIIGaze.h5"
+GAZECAPTURE_FILE="../preprocess/outputs/GazeCapture.h5"
 
 # This batch size should fit a 11GB single GPU
 # The original training used 8x Tesla V100 GPUs.


### PR DESCRIPTION
Previously lines 17 and 18 of the `src/full_train_test_and_plot.bash` were: 
```bash
MPIIGAZE_FILE="../preprocess/outputs/MPIIGaze.h5
GAZECAPTURE_FILE="../preprocess/outputs/GazeCapture.h5
```
because of this the bash script did not run correctly; it always threw an error at line 62.

So, I just added the closing speech marks :)
```bash
MPIIGAZE_FILE="../preprocess/outputs/MPIIGaze.h5"
GAZECAPTURE_FILE="../preprocess/outputs/GazeCapture.h5"
```